### PR TITLE
Add support for custom root name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    light_serializer (0.0.2)
+    light_serializer (0.0.3)
       oj (~> 3)
 
 GEM

--- a/lib/light_serializer.rb
+++ b/lib/light_serializer.rb
@@ -3,6 +3,6 @@
 module LightSerializer
 end
 
-require './lib/light_serializer/hashed_object'
-require './lib/light_serializer/serializer'
-require './lib/light_serializer/version'
+require 'light_serializer/hashed_object'
+require 'light_serializer/serializer'
+require 'light_serializer/version'

--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -14,14 +14,24 @@ module LightSerializer
     end
 
     def get
-      if raw_object.is_a?(Enumerable)
-        raw_object.map { |entity| transform_to_hash(entity) }
-      else
-        transform_to_hash(raw_object)
+      with_custom_root do
+        if raw_object.is_a?(Enumerable)
+          raw_object.map { |entity| transform_to_hash(entity) }
+        else
+          transform_to_hash(raw_object)
+        end
       end
     end
 
     private
+
+    def with_custom_root
+      custom_root ? { custom_root.to_sym => yield } : yield
+    end
+
+    def custom_root
+      @custom_root ||= serializer.root
+    end
 
     def transform_to_hash(object)
       serializer.class.attributes.each_with_object({}) do |attribute, result|

--- a/lib/light_serializer/serializer.rb
+++ b/lib/light_serializer/serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'oj'
-require './lib/light_serializer/hashed_object'
+require 'light_serializer/hashed_object'
 
 module LightSerializer
   class Serializer

--- a/lib/light_serializer/serializer.rb
+++ b/lib/light_serializer/serializer.rb
@@ -5,7 +5,7 @@ require './lib/light_serializer/hashed_object'
 
 module LightSerializer
   class Serializer
-    attr_reader :object
+    attr_reader :object, :root
 
     def self.attributes(*new_attributes)
       return @attributes if new_attributes.empty?
@@ -18,8 +18,9 @@ module LightSerializer
       super(subclass)
     end
 
-    def initialize(object)
+    def initialize(object, root: nil)
       @object = object
+      @root = root
     end
 
     def to_json

--- a/lib/light_serializer/version.rb
+++ b/lib/light_serializer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LightSerializer
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/spec/light_serializer/hashed_object_spec.rb
+++ b/spec/light_serializer/hashed_object_spec.rb
@@ -49,5 +49,14 @@ RSpec.describe LightSerializer::HashedObject do
         expect(hashed_object).to eq(expected_hash)
       end
     end
+
+    context 'when serializer has a custom name for root' do
+      let(:serializer) { TinyWithNestedAttributeSerializer.new(object, root: :tiny_object) }
+      let(:expected_hash) { { tiny_object: { id: 1, name: 'test', nested_attribute: { id: 2, name: 'nested' } } } }
+
+      it 'gets correct hash for it' do
+        expect(hashed_object).to eq(expected_hash)
+      end
+    end
   end
 end

--- a/spec/light_serializer/hashed_object_spec.rb
+++ b/spec/light_serializer/hashed_object_spec.rb
@@ -11,18 +11,18 @@ RSpec.describe LightSerializer::HashedObject do
   let(:serializer) { TinySeriaizer.new(object) }
   let(:expected_hash) { { id: 1, name: 'test' } }
 
-  it 'correctly transform object to hash with correct keys' do
-    expect(hashed_object).to eq(expected_hash)
+  shared_examples 'transform object to correct hash' do
+    specify { expect(hashed_object).to eq(expected_hash) }
   end
+
+  it_behaves_like 'transform object to correct hash'
 
   context 'when serializer has custom methods for one of attribute' do
     let(:object) { OpenStruct.new(id: 1, name: 'test', custom_attribute: 'wrong value') }
     let(:serializer) { BaseSerializer.new(object) }
     let(:expected_hash) { { id: 1, custom_attribute: 'string' } }
 
-    it 'gets value for attributes from serializer first' do
-      expect(hashed_object).to eq(expected_hash)
-    end
+    it_behaves_like 'transform object to correct hash'
   end
 
   context 'when serializer has nested serialization for one of attribute' do
@@ -30,9 +30,7 @@ RSpec.describe LightSerializer::HashedObject do
     let(:serializer) { TinyWithNestedAttributeSerializer.new(object) }
     let(:expected_hash) { { id: 1, name: 'test', nested_attribute: { id: 2, name: 'nested' } } }
 
-    it 'gets correct hash for it' do
-      expect(hashed_object).to eq(expected_hash)
-    end
+    it_behaves_like 'transform object to correct hash'
 
     context 'when attribute is an array of objects' do
       let(:object) do
@@ -45,18 +43,14 @@ RSpec.describe LightSerializer::HashedObject do
       end
       let(:expected_hash) { { id: 1, name: 'test', nested_attribute: [{ id: 2, name: 'nested' }] } }
 
-      it 'gets correct hash for it' do
-        expect(hashed_object).to eq(expected_hash)
-      end
+      it_behaves_like 'transform object to correct hash'
     end
 
     context 'when serializer has a custom name for root' do
       let(:serializer) { TinyWithNestedAttributeSerializer.new(object, root: :tiny_object) }
       let(:expected_hash) { { tiny_object: { id: 1, name: 'test', nested_attribute: { id: 2, name: 'nested' } } } }
 
-      it 'gets correct hash for it' do
-        expect(hashed_object).to eq(expected_hash)
-      end
+      it_behaves_like 'transform object to correct hash'
     end
   end
 end

--- a/spec/light_serializer/serializer_spec.rb
+++ b/spec/light_serializer/serializer_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe LightSerializer::Serializer do
       Oj.load(serialized_object.to_json, mode: :compat, symbol_keys: true)
     end
 
+    before { expected_hash[:created_at] = expected_hash[:created_at].to_s }
+
     it 'returns correct json' do
-      expected_hash[:created_at] = expected_hash[:created_at].to_s
       expect(hash_result).to eq(expected_hash)
     end
 
@@ -65,7 +66,6 @@ RSpec.describe LightSerializer::Serializer do
       let(:expected_hash_with_root) { { custom: expected_hash } }
 
       it 'returns correct json' do
-        expected_hash[:created_at] = expected_hash[:created_at].to_s
         expect(hash_result).to eq(expected_hash_with_root)
       end
     end

--- a/spec/light_serializer/serializer_spec.rb
+++ b/spec/light_serializer/serializer_spec.rb
@@ -58,5 +58,16 @@ RSpec.describe LightSerializer::Serializer do
       expected_hash[:created_at] = expected_hash[:created_at].to_s
       expect(hash_result).to eq(expected_hash)
     end
+
+    context 'when serializer has a custom name for root' do
+      subject(:serialized_object) { ChildSerializer.new(object, root: :custom) }
+
+      let(:expected_hash_with_root) { { custom: expected_hash } }
+
+      it 'returns correct json' do
+        expected_hash[:created_at] = expected_hash[:created_at].to_s
+        expect(hash_result).to eq(expected_hash_with_root)
+      end
+    end
   end
 end


### PR DESCRIPTION
Поддержка кастомного имени для `root` элемента сериализованных данных.

Так же немного поправил пути в `require`