### PR TITLE
Add support for context in serializers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    light_serializer (0.0.3)
+    light_serializer (0.0.4)
       oj (~> 3)
 
 GEM

--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -51,7 +51,7 @@ module LightSerializer
       attribute_name = attribute.keys.last
       nested_serializer = attribute.values.last
       value = obtain_value(object, attribute_name)
-      result[attribute_name] = nested_serializer.new(value).to_hash
+      result[attribute_name] = nested_serializer.new(value, context: serializer.context).to_hash
     end
 
     def values_from_current_resource(attribute, object, result)

--- a/lib/light_serializer/serializer.rb
+++ b/lib/light_serializer/serializer.rb
@@ -5,7 +5,7 @@ require 'light_serializer/hashed_object'
 
 module LightSerializer
   class Serializer
-    attr_reader :object, :root
+    attr_reader :object, :root, :context
 
     def self.attributes(*new_attributes)
       return @attributes if new_attributes.empty?
@@ -18,9 +18,10 @@ module LightSerializer
       super(subclass)
     end
 
-    def initialize(object, root: nil)
+    def initialize(object, root: nil, context: nil)
       @object = object
       @root = root
+      @context = context
     end
 
     def to_json

--- a/lib/light_serializer/version.rb
+++ b/lib/light_serializer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LightSerializer
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/spec/light_serializer/serializer_spec.rb
+++ b/spec/light_serializer/serializer_spec.rb
@@ -69,5 +69,25 @@ RSpec.describe LightSerializer::Serializer do
         expect(hash_result).to eq(expected_hash_with_root)
       end
     end
+
+    context 'when provide context for serialization' do
+      subject(:serialized_object) { TinyWithContext.new(object, context: context) }
+
+      let(:context) { OpenStruct.new(url: 'https://www.example.com') }
+
+      it 'correctly serialize data from context' do
+        expect(hash_result[:url_from_context]).to eq(context.url)
+      end
+    end
+
+    context 'when provided context is used in nested serializer' do
+      subject(:serialized_object) { ChildWithContext.new(object, context: context) }
+
+      let(:context) { OpenStruct.new(url: 'https://www.example.com') }
+
+      it 'correctly serialize data from context' do
+        expect(hash_result[:nested_attribute][:url_from_context]).to eq(context.url)
+      end
+    end
   end
 end

--- a/spec/shared/contexts/serializers.rb
+++ b/spec/shared/contexts/serializers.rb
@@ -16,6 +16,22 @@ RSpec.shared_context 'with base and nested serializers' do
     )
   end
 
+  class TinyWithContext < ::LightSerializer::Serializer
+    attributes(
+      :url_from_context
+    )
+
+    def url_from_context
+      context.url
+    end
+  end
+
+  class ChildWithContext < TinyWithContext
+    attributes(
+      nested_attribute: TinyWithContext
+    )
+  end
+
   class BaseSerializer < ::LightSerializer::Serializer
     attributes(
       :id,


### PR DESCRIPTION
Возможно использовать внешний контекст (например `view_context` из Rails) в сериализации.