### PR TITLE
Add component for hash/serialize collections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    light_serializer (0.0.4)
+    light_serializer (0.0.5)
       oj (~> 3)
 
 GEM

--- a/lib/light_serializer.rb
+++ b/lib/light_serializer.rb
@@ -3,6 +3,8 @@
 module LightSerializer
 end
 
+require 'light_serializer/helpers/with_custom_root'
 require 'light_serializer/hashed_object'
 require 'light_serializer/serializer'
+require 'light_serializer/serialize_collection'
 require 'light_serializer/version'

--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -46,11 +46,13 @@ module LightSerializer
     end
 
     def hashed_nested_resource(value, nested_serializer)
-      if value.is_a?(Array)
-        value.map { |entity| nested_serializer.new(entity, context: serializer.context).to_hash }
-      else
-        nested_serializer.new(value, context: serializer.context).to_hash
-      end
+      return hashed_entity(value, nested_serializer) unless value.is_a?(Enumerable)
+
+      value.each_with_object(nested_serializer).map(&method(:hashed_entity))
+    end
+
+    def hashed_entity(entity, nested_serializer)
+      nested_serializer.new(entity, context: serializer.context).to_hash
     end
 
     def values_from_current_resource(attribute, object, result)

--- a/lib/light_serializer/helpers/with_custom_root.rb
+++ b/lib/light_serializer/helpers/with_custom_root.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module LightSerializer::Helpers
+  module WithCustomRoot
+    def with_custom_root(root)
+      root ? { root.to_sym => yield } : yield
+    end
+  end
+end

--- a/lib/light_serializer/serialize_collection.rb
+++ b/lib/light_serializer/serialize_collection.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'light_serializer/helpers/with_custom_root'
+require 'light_serializer/serializer'
+
+module LightSerializer
+  class SerializeCollection
+    include Helpers::WithCustomRoot
+
+    attr_reader :collection, :serializer, :root, :context
+
+    def initialize(collection, serializer:, root: nil, context: nil)
+      @collection = collection
+      @serializer = serializer
+      @root = root
+      @context = context
+    end
+
+    def to_json
+      with_custom_root(root) { Oj.dump(hashed_collection, mode: :compat) }
+    end
+
+    def to_hash
+      hashed_collection
+    end
+
+    private
+
+    def hashed_collection
+      collection.map { |entity| serializer.new(entity, context: context).to_hash }
+    end
+  end
+end

--- a/lib/light_serializer/version.rb
+++ b/lib/light_serializer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LightSerializer
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/light_serializer/serialize_collection_spec.rb
+++ b/spec/light_serializer/serialize_collection_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'light_serializer/serialize_collection'
+
+RSpec.describe LightSerializer::SerializeCollection do
+  include_context 'with base and nested serializers'
+
+  subject(:serialized_collection) { described_class.new(collection, serializer: ChildWithUsingObject) }
+
+  let(:collection) do
+    [OpenStruct.new(id: 1, name: 'ololo', nested_resources: [OpenStruct.new(id: 1, name: 'nested_ololo')])]
+  end
+  let(:expected_hash) do
+    [{ uuid: 1, login: 'ololo', nested_resources: [{ login: 'nested_ololo' }] }]
+  end
+
+  context '#to_json' do
+    let(:hash_result) do
+      Oj.load(serialized_collection.to_json, mode: :compat, symbol_keys: true)
+    end
+
+    it 'correctly serialized collection' do
+      expect(hash_result).to eq(expected_hash)
+    end
+  end
+
+  context '#to_hash' do
+    let(:hash_result) { serialized_collection.to_hash }
+
+    it 'correctly hashed collection' do
+      expect(hash_result).to eq(expected_hash)
+    end
+  end
+end

--- a/spec/shared/contexts/serializers.rb
+++ b/spec/shared/contexts/serializers.rb
@@ -32,6 +32,27 @@ RSpec.shared_context 'with base and nested serializers' do
     )
   end
 
+  class TinyWithUsingObject < ::LightSerializer::Serializer
+    attributes(
+      :login
+    )
+
+    def login
+      object.name
+    end
+  end
+
+  class ChildWithUsingObject < TinyWithUsingObject
+    attributes(
+      :uuid,
+      nested_resources: TinyWithUsingObject
+    )
+
+    def uuid
+      object.id
+    end
+  end
+
   class BaseSerializer < ::LightSerializer::Serializer
     attributes(
       :id,


### PR DESCRIPTION
Есть особенность для сериализации массива объектов: 
необходимо учитывать, что внутри сериалайзера будет использоваться сериализуемый объект, как одна сущность. Сейчас у нас была поддержка сериализации коллекций, если просто передать  как `object = [...]` из объектов, но тогда, если в кастомных методах сериалайзера вызываются методы на `object`, они будут вызываться на массиве и это все поломает.
Создал отдельную сущность для сериализации/хэширования коллекций, которая для каждого элемент коллекции создают отдельный инстанс нужного сериалайзера + убрал поддержку хэширования коллекции у `HashedObject`, т.к. теперь он должен хэшировать только 1 объект