### PR TITLE
Fix stack level too deep problem when use collection's serializer inside another serializer

### DIFF
--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -46,9 +46,13 @@ module LightSerializer
     end
 
     def hashed_nested_resource(value, nested_serializer)
-      return hashed_entity(value, nested_serializer) unless value.is_a?(Enumerable)
+      return hashed_entity(value, nested_serializer) unless can_be_enumerated?(value)
 
       value.each_with_object(nested_serializer).map(&method(:hashed_entity))
+    end
+
+    def can_be_enumerated?(value)
+      value.is_a?(Enumerable) || value.respond_to?(:each)
     end
 
     def hashed_entity(entity, nested_serializer)
@@ -76,7 +80,7 @@ module LightSerializer
     end
 
     def values_from_for_array(attribute, value, result)
-      value.map { |entity| obtain_values(attribute, entity, result) }
+      value.map { |entity| entity.is_a?(Hash) ? entity : obtain_values(attribute, entity, result) }
     end
   end
 end

--- a/spec/light_serializer/serialize_collection_spec.rb
+++ b/spec/light_serializer/serialize_collection_spec.rb
@@ -31,4 +31,17 @@ RSpec.describe LightSerializer::SerializeCollection do
       expect(hash_result).to eq(expected_hash)
     end
   end
+
+  context 'when one of serializers use SerializeCollection in custom method' do
+    subject(:serialized_collection) { ChildWithSerializeCollection.new(collection.first) }
+
+    let(:expected_hash) do
+      { id: 1, login: 'ololo', nested_resources: [{ login: 'nested_ololo' }] }
+    end
+    let(:hash_result) { serialized_collection.to_hash }
+
+    it 'correctly hashed it' do
+      expect(hash_result).to eq(expected_hash)
+    end
+  end
 end

--- a/spec/shared/contexts/serializers.rb
+++ b/spec/shared/contexts/serializers.rb
@@ -53,6 +53,17 @@ RSpec.shared_context 'with base and nested serializers' do
     end
   end
 
+  class ChildWithSerializeCollection < TinyWithUsingObject
+    attributes(
+      :id,
+      :nested_resources
+    )
+
+    def nested_resources
+      ::LightSerializer::SerializeCollection.new(object.nested_resources, serializer: TinyWithUsingObject).to_hash
+    end
+  end
+
   class BaseSerializer < ::LightSerializer::Serializer
     attributes(
       :id,


### PR DESCRIPTION
Обнаружили проблему, что если пытаться использоваться штуку для сериализации коллекции внутри другого сериалайзера, через кастомный метод, то будет `Stack level too deep`. Фикс