### PR TITLE
small performance improvement

### DIFF
--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -50,7 +50,11 @@ module LightSerializer
     end
 
     def can_be_enumerated?(value)
-      value.is_a?(Enumerable) || value.respond_to?(:each)
+      value.is_a?(Enumerable) || active_record_relation?(value)
+    end
+
+    def active_record_relation?(object)
+      !!(defined?(ActiveRecord::Relation) && object.is_a?(ActiveRecord::Relation))
     end
 
     def hashed_entity(entity, nested_serializer)

--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -36,8 +36,8 @@ module LightSerializer
     end
 
     def values_from_nested_resource(attribute, object, result)
-      attribute_name = attribute.keys.last
-      nested_serializer = attribute.values.last
+      attribute_name = attribute.keys[-1]
+      nested_serializer = attribute.values[-1]
 
       value = obtain_value(object, attribute_name)
       result[attribute_name] = hashed_nested_resource(value, nested_serializer)

--- a/lib/light_serializer/serializer.rb
+++ b/lib/light_serializer/serializer.rb
@@ -7,7 +7,7 @@ module LightSerializer
     def self.attributes(*new_attributes)
       return @attributes if new_attributes.empty?
 
-      @attributes = @attributes ? @attributes + new_attributes : new_attributes
+      @attributes = @attributes ? @attributes.concat(new_attributes) : new_attributes
     end
 
     def self.inherited(subclass)


### PR DESCRIPTION
не создаем новый объект с аттрибутами

```
Warming up --------------------------------------
Light (associations): collection through .to_json
                         1.000  i/100ms
Blueprinter (associations): collection
                         1.000  i/100ms
Calculating -------------------------------------
Light (associations): collection through .to_json
                         12.617  (± 7.9%) i/s -     63.000  in   5.072740s
Blueprinter (associations): collection
                         12.399  (± 8.1%) i/s -     62.000  in   5.062292s

Comparison:
Light (associations): collection through .to_json:       12.6 i/s
Blueprinter (associations): collection:       12.4 i/s - same-ish: difference falls within error
```