### PR TITLE
Fix work with many nested attributes. Fix work with empty attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,12 @@
 PATH
   remote: .
   specs:
-    light_serializer (0.0.8)
+    light_serializer (0.0.9)
       oj (~> 3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.10)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
     ast (2.4.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -23,21 +18,15 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     equalizer (0.0.11)
-    factory_bot (4.11.1)
-      activesupport (>= 3.0.0)
-    i18n (0.9.5)
-      concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.1)
     kwalify (0.7.2)
     method_source (0.9.0)
-    minitest (5.11.3)
-    oj (3.7.4)
+    oj (3.7.6)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -80,8 +69,6 @@ GEM
       rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -94,7 +81,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.0)
-  factory_bot (~> 4.11)
   light_serializer!
   pry-byebug (~> 3.0)
   rake (~> 10.0)
@@ -104,4 +90,4 @@ DEPENDENCIES
   rubocop-rspec (~> 1.30)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/lib/light_serializer/hashed_object.rb
+++ b/lib/light_serializer/hashed_object.rb
@@ -35,12 +35,11 @@ module LightSerializer
       end
     end
 
-    def values_from_nested_resource(attribute, object, result)
-      attribute_name = attribute.keys[-1]
-      nested_serializer = attribute.values[-1]
-
-      value = obtain_value(object, attribute_name)
-      result[attribute_name] = hashed_nested_resource(value, nested_serializer)
+    def values_from_nested_resource(attributes, object, result)
+      attributes.each do |attribute_name, nested_serializer|
+        value = obtain_value(object, attribute_name)
+        result[attribute_name] = hashed_nested_resource(value, nested_serializer)
+      end
     end
 
     def hashed_nested_resource(value, nested_serializer)

--- a/lib/light_serializer/serializer.rb
+++ b/lib/light_serializer/serializer.rb
@@ -6,7 +6,7 @@ module LightSerializer
     attr_reader :object, :root, :context, :meta
 
     def self.attributes(*new_attributes)
-      return @attributes if new_attributes.empty?
+      return (@attributes || []) if new_attributes.empty?
 
       @attributes = @attributes ? @attributes.concat(new_attributes) : new_attributes
     end

--- a/lib/light_serializer/version.rb
+++ b/lib/light_serializer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LightSerializer
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'
 end

--- a/light_serializer.gemspec
+++ b/light_serializer.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
   spec.add_dependency 'oj', '~> 3'
   spec.add_development_dependency 'bundler', '~> 1.0'
-  spec.add_development_dependency 'factory_bot', '~> 4.11'
   spec.add_development_dependency 'pry-byebug', '~> 3.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'reek', '~> 5.1'

--- a/spec/light_serializer/hashed_object_spec.rb
+++ b/spec/light_serializer/hashed_object_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe LightSerializer::HashedObject do
 
   it_behaves_like 'transform object to correct hash'
 
+  context 'when serializer with empty attributes' do
+    let(:object) { OpenStruct.new(id: 1) }
+    let(:serializer) { EmptySeriaizer.new(object) }
+    let(:expected_hash) { {} }
+
+    it_behaves_like 'transform object to correct hash'
+  end
+
   context 'when serializer has custom methods for one of attribute' do
     let(:object) { OpenStruct.new(id: 1, name: 'test', custom_attribute: 'wrong value') }
     let(:serializer) { BaseSerializer.new(object) }
@@ -26,9 +34,23 @@ RSpec.describe LightSerializer::HashedObject do
   end
 
   context 'when serializer has nested serialization for one of attribute' do
-    let(:object) { OpenStruct.new(id: 1, name: 'test', nested_attribute: OpenStruct.new(id: 2, name: 'nested')) }
+    let(:object) do
+      OpenStruct.new(
+        id: 1,
+        name: 'test',
+        nested_attribute: OpenStruct.new(id: 2, name: 'nested'),
+        additional_nested_attribute: OpenStruct.new(id: 3, name: 'additional_nested')
+      )
+    end
     let(:serializer) { TinyWithNestedAttributeSerializer.new(object) }
-    let(:expected_hash) { { id: 1, name: 'test', nested_attribute: { id: 2, name: 'nested' } } }
+    let(:expected_hash) do
+      {
+        id: 1,
+        name: 'test',
+        nested_attribute: { id: 2, name: 'nested' },
+        additional_nested_attribute: { id: 3, name: 'additional_nested' }
+      }
+    end
 
     it_behaves_like 'transform object to correct hash'
 
@@ -38,17 +60,25 @@ RSpec.describe LightSerializer::HashedObject do
           id: 1,
           extra_field: 'extra',
           name: 'test',
-          nested_attribute: [OpenStruct.new(id: 2, extra_field: 'nested_extra', name: 'nested')]
+          nested_attribute: [OpenStruct.new(id: 2, extra_field: 'nested_extra', name: 'nested')],
+          additional_nested_attribute: [OpenStruct.new(id: 3, extra_field: 'nested_extra', name: 'additional_nested')]
         )
       end
-      let(:expected_hash) { { id: 1, name: 'test', nested_attribute: [{ id: 2, name: 'nested' }] } }
+      let(:expected_hash) do
+        {
+          id: 1,
+          name: 'test',
+          nested_attribute: [{ id: 2, name: 'nested' }],
+          additional_nested_attribute: [{ id: 3, name: 'additional_nested' }]
+        }
+      end
 
       it_behaves_like 'transform object to correct hash'
     end
 
     context 'when serializer has a custom name for root' do
       let(:serializer) { TinyWithNestedAttributeSerializer.new(object, root: :tiny_object) }
-      let(:expected_hash) { { 'tiny_object' => { id: 1, name: 'test', nested_attribute: { id: 2, name: 'nested' } } } }
+      let(:expected_hash) { { 'tiny_object' => super() } }
 
       it_behaves_like 'transform object to correct hash'
     end

--- a/spec/shared/contexts/serializers.rb
+++ b/spec/shared/contexts/serializers.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'with base and nested serializers' do
+  class EmptySeriaizer < ::LightSerializer::Serializer
+    attributes()
+  end
+
   class TinySeriaizer < ::LightSerializer::Serializer
     attributes(
       :id,
@@ -12,7 +16,8 @@ RSpec.shared_context 'with base and nested serializers' do
     attributes(
       :id,
       :name,
-      nested_attribute: TinySeriaizer
+      nested_attribute: TinySeriaizer,
+      additional_nested_attribute: TinySeriaizer
     )
   end
 


### PR DESCRIPTION
Fix: https://github.com/krim/light_serializer/issues/16
When we have many nested attributes with custom serializers it returns only last serialized attribute.

Remove unneeded `factory_bot` dependency